### PR TITLE
mysql: only use g++-uc wrapper with uClibc++

### DIFF
--- a/utils/mysql/Makefile
+++ b/utils/mysql/Makefile
@@ -58,7 +58,9 @@ define Package/libmysqlclient-r
   DEPENDS+= +libpthread
 endef
 
-TARGET_CXX=g++-uc
+ifneq ($(CONFIG_USE_UCLIBCXX),)
+  TARGET_CXX=g++-uc
+endif
 
 TARGET_CFLAGS += $(FPIC)
 


### PR DESCRIPTION
Signed-off-by: Nicolas Thill <nico@openwrt.org>